### PR TITLE
build(deps): bump certifi 2023.7.22 -> 2024.7.4 (Dependabot follow-up)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-certifi==2023.7.22
+certifi==2024.7.4
 chardet==3.0.4
 click==6.7
 Flask==3.1.3


### PR DESCRIPTION
The prior bump to 2023.7.22 was still vulnerable to a newer certifi advisory (< 2024.7.4). Bumps to 2024.7.4 (alert-free).